### PR TITLE
chore: gitignore api/staging Azure Functions build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ out/
 build/
 dist/
 .cache/
+api/staging/
 
 # misc
 .DS_Store


### PR DESCRIPTION
## Summary

- Adds `api/staging/` to `.gitignore` — Azure Functions deployment build output
- Same pattern as PR #19 (`gitignore api build artifacts`)

## Test plan

- [ ] Standards Compliance check passes
- [ ] Trivy fs / IaC / secrets scans pass
- [ ] Gate on HIGH / CRITICAL passes
- [ ] Working tree is clean after merge (no more untracked `api/staging/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)