### PR TITLE
docs(strategy): strategic review, roadmap, and execution plans

### DIFF
--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -1,0 +1,41 @@
+# SchedulEd — Strategy & Execution Handoff
+
+Strategic review of the AIStudyPlans (SchedulEd) repo, written by Claude Fable 5 for
+execution by later Claude Opus sessions with no memory of the review. **Planning
+artifacts only — no source was changed.**
+
+## Read in this order
+1. **`STRATEGIC_REVIEW.md`** — the assessment: architecture health, tech-debt
+   inventory, security posture, risks/opportunities, health verdict (5/10).
+2. **`ROADMAP.md`** — Now / Next / Later, sequencing, and explicit anti-goals.
+3. **`plans/PLAN-NNN-*.md`** — one self-contained, executable plan per Now/Next item.
+
+## Executing a plan
+Open one `PLAN-NNN` file in a fresh session: *"Read
+`docs/strategy/plans/PLAN-001-*.md`. Implement exactly as written. Update Status and
+record Validation results when done."* One plan per session keeps context clean.
+
+## Execution order (from ROADMAP.md)
+**Now:** 000 → 001 → 002 → 003 → 004 → 005. **Next:** 006 → 007 → 008 → 009.
+
+| Plan | Title | Effort · Risk |
+|---|---|---|
+| PLAN-000 | Rotate & scrub the committed production secret | S/L · Med |
+| PLAN-001 | Close the `/api/admin/*` authorization gap | S · Low |
+| PLAN-002 | Remove production debug endpoints | S · Low |
+| PLAN-003 | Purge dead code & tracked junk | M · Low |
+| PLAN-004 | Reconcile CLAUDE.md with reality | M · Low |
+| PLAN-005 | Add a CI validation gate | S · Low |
+| PLAN-006 | Declare SWA canonical; freeze the Functions backend | M · Med |
+| PLAN-007 | Resolve CSRF & fix rate-limiting for Azure edge | M · Low |
+| PLAN-008 | Kill test theater & backfill critical-path tests | M · Low |
+| PLAN-009 | Consolidate docs & seed an ADR system | M · Low |
+
+## Do first, before touching any plan
+**PLAN-000.** A live Resend API key is committed in `update-production-env.sh` and is
+weekly-mirrored to the backup repo. Rotate it before anything else.
+
+## Anti-goals (don't drift — see ROADMAP.md)
+Don't migrate the frontend onto the Functions backend; don't rewrite working
+components during cleanup; don't bundle dependency majors; don't delete Azure infra
+before the L-1 trigger; don't add `/api/admin/*` routes before PLAN-001.

--- a/docs/strategy/ROADMAP.md
+++ b/docs/strategy/ROADMAP.md
@@ -1,0 +1,122 @@
+# SchedulEd (AIStudyPlans) — Roadmap
+
+**Companion to** `STRATEGIC_REVIEW.md`. Each Now/Next item has a `plans/PLAN-NNN-*.md`
+with pre-resolved, executable steps. Later items are triggers, not yet plans.
+
+**Sequencing principle:** boring and reversible first. Security exposure (secret,
+auth) → hygiene/truth (dead code, docs, CI gate) → structural consolidation
+(backend, tests) → strategic bets (upgrades, infra teardown).
+
+---
+
+## NOW (0–30 days) — highest leverage, lowest risk
+
+| # | Plan | Effort | Risk | Why now |
+|---|---|---|---|---|
+| 0 | **PLAN-000 — Rotate & scrub the committed secret** | S (rotate) / L (scrub) | Med | A live Resend key sits in git + weekly backups. This is the only *actively exploitable* item. Do it first. |
+| 1 | **PLAN-001 — Close the `/api/admin/*` authorization gap** | S | Low | Two HIGH auth findings; surgical middleware + per-route fix. |
+| 2 | **PLAN-002 — Remove production debug endpoints** | S | Low | Ungated env/config disclosure; pure deletion. |
+| 3 | **PLAN-003 — Purge dead code & tracked junk** | M | Low | 37 `.bak`, `src/` boilerplate, junk files. Deletion only; git is the rollback. Makes every later plan cheaper. |
+| 4 | **PLAN-004 — Reconcile CLAUDE.md with reality** | M | Low | Every future session reads it first; fixing it compounds. |
+| 5 | **PLAN-005 — Add a CI validation gate** | S | Low | Make the existing passing tests actually protect the deploy. |
+
+**Ordering within Now:** `PLAN-000` is independent and first. `PLAN-001`/`002` are
+independent security fixes (any order). `PLAN-003` should land **before** `PLAN-004`
+(deleting dead files changes what the docs must describe) and gives `PLAN-005` a
+clean tree to gate. `PLAN-005` should land **after** `003` so the first gated build
+isn't fighting lint errors in soon-to-be-deleted files.
+
+Recommended execution order: **000 → 001 → 002 → 003 → 004 → 005.**
+
+---
+
+## NEXT (30–90 days) — structural moves
+
+| # | Plan | Effort | Risk | Depends on |
+|---|---|---|---|---|
+| 6 | **PLAN-006 — Declare SWA API routes canonical; freeze the Functions backend** | M | Med | 004 (docs must first tell the truth about the split) |
+| 7 | **PLAN-007 — Resolve CSRF + fix rate-limiting for Azure edge** | M | Low | 001, 006 (touches the canonical route set) |
+| 8 | **PLAN-008 — Kill test theater & backfill critical-path tests** | M | Low | 005 (gate must exist for tests to protect anything) |
+| 9 | **PLAN-009 — Consolidate docs & seed an ADR system** | M | Low | 003, 004, 006 (ADRs record the decisions those plans make) |
+
+**The load-bearing decision (pre-resolved in PLAN-006):** the **Azure SWA Next.js
+API routes are canonical**; the standalone Azure Functions backend (`api/`) is
+frozen and marked for decommission. Rationale: the frontend already calls the SWA
+routes exclusively (`app/hooks/useWaitlistForm.ts:133-150`), the Functions copy
+serves zero traffic, SWA managed functions are more than adequate for waitlist
+volume, and maintaining two divergent trees is the repo's biggest bug vector.
+Consolidating *toward reality* is lower-risk than migrating the frontend to the
+documented-but-unused Functions path. PLAN-006 does the low-risk half (declare +
+de-duplicate + freeze); the actual infra teardown is a Later item with a trigger.
+
+---
+
+## LATER (90 days+) — strategic bets, each gated by a trigger
+
+- **L-1. Decommission the Azure Functions backend infrastructure.**
+  *Trigger:* PLAN-006 shipped **and** SWA routes confirmed serving 100% of prod
+  traffic for 30 days with no consumer needing Functions. *Then:* delete `api/`,
+  remove the Functions/Storage resources from `infra/main.bicep`, retire the
+  `func-btai-asp-prod` KV references. Reversible until the `az deployment`;
+  irreversible after — hence the wait.
+
+- **L-2. Breaking-major dependency upgrade campaign.** Held majors:
+  `next 15→16`, `tailwindcss 3→4`, `eslint 9→10`, `vitest 3→4`, `zod 3→4`,
+  `@types/node 20→22/26`, `typescript 5→6`, `@vitejs/plugin-react 4→6`,
+  `react-intersection-observer 9→10`. *Trigger:* PLAN-008 shipped (real tests give
+  the safety net an upgrade campaign requires). *Sequence:* one PR per major, lowest
+  blast-radius first (`@types/node`, `zod`, `vitest`), highest last (`next`,
+  `tailwind` — see BTAISite CLAUDE.md "Critical: Tailwind CSS v4 Rules" **before**
+  touching Tailwind). `next-auth` beta→stable is part of the `next` upgrade PR.
+  Do **not** bundle majors.
+
+- **L-3. Collapse the two landing implementations into one.**
+  *Trigger:* a product decision on which page (`/` vs `/landing`) is canonical.
+  *Then:* delete the losing component set and its route. Blocked on a human product
+  call, not an engineering one.
+
+- **L-4. Durable rate limiting + email quota (Redis/Upstash).**
+  *Trigger:* observed abuse **or** waitlist volume high enough that per-instance
+  in-memory limits demonstrably fail (App Insights shows limit resets/multiplication
+  causing either bypass or false blocks). Until then, the in-memory limiter is
+  adequate for the volume and not worth an external dependency.
+
+- **L-5. Move Supabase writes behind the server with least privilege.**
+  *Trigger:* any move to store real (non-mock) admin/contact data, or a SOC 2
+  access-control control that requires it. *Then:* writes go through the server using
+  the service-role key with verified RLS, not the client-exposed anon key.
+
+---
+
+## Anti-goals — what NOT to do (and why)
+
+- **Do NOT migrate the frontend to call the Azure Functions backend** to "make the
+  docs true." The docs are wrong, not the code. Fix the docs (`PLAN-004`) and
+  consolidate toward the running system (`PLAN-006`). Migrating live traffic onto
+  the untested Functions copy would add risk to serve zero benefit.
+
+- **Do NOT rewrite, restructure, or "modernize" working component code** while
+  cleaning up. `PLAN-003` is deletion of dead files only. Resist the urge to refactor
+  `Hero`, the email templates, or the admin pages in the same pass — that turns a
+  reversible cleanup into a risky change.
+
+- **Do NOT bundle dependency majors** (see L-2). Each major (Next, Tailwind, ESLint,
+  Zod, Vitest) is its own PR with its own rollback. A combined bump is
+  unbisectable.
+
+- **Do NOT delete the Azure Functions infra in the Now/Next window.** Freeze it
+  (`PLAN-006`), confirm traffic (L-1 trigger), then tear down. Deleting live cloud
+  infra before confirming nothing depends on it is the one genuinely irreversible
+  move here.
+
+- **Do NOT invest in the admin dashboard's mock data paths** (`email-stats`
+  hardcoded, `admin-supabase` in-memory) as if they were real. Either wire real data
+  *with* auth (`PLAN-001` first) or leave them clearly labeled as mock. Building
+  features on the mock deepens the auth-gap risk.
+
+- **Do NOT add new API endpoints under `app/api/admin/` until `PLAN-001` lands.**
+  They would silently inherit the middleware bypass and ship unauthenticated.
+
+- **Do NOT "fix" security by re-enabling the decorative CSRF** without deciding it's
+  actually needed. `PLAN-007` resolves the CSRF question deliberately; half-wiring a
+  validator that clients don't send tokens for adds friction without protection.

--- a/docs/strategy/STRATEGIC_REVIEW.md
+++ b/docs/strategy/STRATEGIC_REVIEW.md
@@ -1,0 +1,300 @@
+# SchedulEd (AIStudyPlans) — Strategic Review
+
+**Reviewer:** Claude Fable 5 (architecture pass, planning only — no source changed)
+**Date:** 2026-07-03
+**Repo:** `/Users/herculeanfit1/dev/AIStudyPlans` · branch `main` @ `72cb9c33`
+**Companion docs:** `ROADMAP.md`, `plans/PLAN-*.md`
+
+> This review is written for an executor (Claude Opus) with **zero memory of this
+> session**. Every claim cites a file path. Where a finding drove a decision, the
+> decision is pre-made in the matching `plans/PLAN-NNN-*.md`.
+
+---
+
+## 1. Purpose & Portfolio Fit
+
+**What it is.** SchedulEd is the consumer-facing landing page and waitlist funnel
+for an AI study-plan product under Bridging Trust AI. It is a Next.js 15 / React 19
+app deployed to Azure Static Web Apps (SSR/hybrid — confirmed: `next.config.mjs`
+has no `output: "export"`). It collects waitlist signups and contact/feedback
+submissions, stores them in Supabase, and sends transactional email via Resend. An
+admin dashboard (Auth.js v5 + Microsoft Entra ID) surfaces email/feedback stats.
+
+**Who consumes it.** End users (students, parents, educators) hit the public
+funnel; the owner (TK) uses the admin dashboard. No other system depends on this
+repo — it is a leaf, not a hub.
+
+**Fleet fit.** Per `STANDARDS.md:21`, this is classified a **non-agent external
+repo** in the Herculean ecosystem — the lowest-trust, internet-facing tier. It is a
+marketing/lead-capture surface, not infrastructure. That classification matters:
+the security baseline that applies is `STANDARDS.md` (Trivy scan, Dependabot,
+branch protection, no committed secrets), **not** the full agent-repo standard.
+There is a live contradiction here (see §3, Doc Drift): `CLAUDE.md:30` treats the
+repo as an *agent* repo governed by "Standards v1.1" while `STANDARDS.md` is the
+*non-agent* v1.0 standard that explicitly exempts this repo from the agent
+workflow. The repo currently carries both sets of machinery.
+
+---
+
+## 2. Architecture Health
+
+### 2.1 What's genuinely good
+- **Dependency hygiene is real.** Exact-pinned versions (`package.json:75-116`),
+  `npm-shrinkwrap.json` committed and force-kept (`.gitignore:76-77`), Dependabot
+  configured (`.github/dependabot.yml`), Trivy fs/config/secret scanning with a
+  HIGH/CRITICAL gate (`.github/workflows/security-scan.yml`). This is the
+  strongest part of the repo.
+- **The NextAuth core is sound.** `auth.ts:45-63` rejects non-allowlisted emails at
+  `signIn`, derives `isAdmin` server-side into the JWT, and the `/admin/*` *page*
+  routes are gated by real server-side middleware (`middleware.ts:24-36`).
+- **Input validation is solid where used.** Zod schemas with length caps and email
+  validation for waitlist and all contact forms (`lib/validation.ts:6-119`).
+- **Build enforces types & lint.** `next.config.mjs:29-34` keeps
+  `ignoreBuildErrors:false` and `ignoreDuringBuilds:false`.
+
+### 2.2 Structural risks (ranked)
+
+**R-A. Duplicated backend — every endpoint exists twice.** The single biggest
+structural liability. `lib/*` + `app/api/*` (the SWA copy) and `api/src/*` (the
+standalone Azure Functions copy) are parallel implementations of the same
+endpoints. Nine `lib/` files are byte-identical between the two trees
+(`supabase.ts`, `admin-supabase.ts`, `email.ts`, `email-templates.ts`,
+`email-monitor.ts`, `validation.ts`, `types.ts`, `contact.ts`,
+`feedback-email-templates.ts`); `rate-limit.ts` has **already diverged 143 lines**.
+Any fix must be applied twice or the copies rot. **The Functions backend is dead in
+the request path** — see R-B.
+
+**R-B. Documented architecture ≠ running architecture.** `CLAUDE.md:112-198`
+describes waitlist/contact/feedback as "moved to Azure Functions," with the browser
+calling `func-btai-asp-prod` via CORS. **Reality:** the waitlist form posts to
+`${NEXT_PUBLIC_APP_URL}/api/waitlist` = `https://aistudyplans.com/api/waitlist`
+(`app/hooks/useWaitlistForm.ts:133-150`, `.env.production:22`), which is the
+**Next.js SWA route** (`app/api/waitlist/route.ts`). Contact and feedback forms
+likewise call SWA routes (`app/contact/sales/page.tsx:31`,
+`app/feedback/page.tsx:45`). **No frontend form calls the Functions backend.** The
+Functions app is deployed infrastructure that serves zero production traffic.
+
+**R-C. Two full landing-page implementations.** `/` (`app/page.tsx`) renders one
+component set (`app/components/Hero|Features|Footer|HowItWorks`); `/landing`
+(`app/landing/page.tsx`) renders a parallel set
+(`app/components/landing/*Section`). Both routes are live; nothing links them.
+Double the surface for one product page.
+
+**R-D. Dead weight drowns the signal.** 37 tracked `.bak` files
+(`app/components/*.bak`, `components/*.bak`), an untouched create-next-app
+boilerplate at `src/app/` (`src/app/page.tsx` still says "Get started by editing…"),
+~11 never-imported duplicate components under root `components/`, a committed
+`~/Library/Application Support/Cursor/User/settings.json` (a literal `~` dir),
+`package-lock.json.backup` (483 KB), zero-byte tracked logs, and 51 files in
+`docs/` (many point-in-time fix logs). This inflates every future review and
+every grep.
+
+### 2.3 Coupling & scaling
+- **Coupling hot spot:** the `lib/` ↔ `api/src/lib/` duplication (R-A). There is no
+  shared package; the two trees are copy-paste-coupled.
+- **Scaling ceiling (functional):** rate limiting and the email quota circuit
+  breaker are in-memory per-instance (`lib/rate-limit.ts:16-17`,
+  `lib/email-monitor.ts`). On SWA managed functions and Functions Flex Consumption,
+  counters reset on cold start and multiply by instance count — so the "5/hr"
+  waitlist cap is effectively `5 × live_instances` and resets frequently. For a
+  low-volume funnel this is tolerable today; it is not a real abuse control.
+
+---
+
+## 3. Documentation vs. Reality Drift
+
+`CLAUDE.md` is the file every future session reads first, so its drift is
+high-leverage to fix (see `PLAN-004`). Confirmed inaccuracies:
+
+| CLAUDE.md claim | Reality |
+|---|---|
+| L112-198: waitlist/contact/feedback moved to Functions; frontend calls Functions via CORS | Frontend calls **SWA Next.js routes**; Functions serves no traffic (R-B) |
+| L96-102: `src/app/` is a "secondary/legacy entry point … backup layout" | `src/app/` is untouched create-next-app boilerplate, unrouted/dead |
+| L166: admin access controlled by `ADMIN_EMAILS` env var | `ADMIN_EMAILS` is **read by no code**; allowlist is hardcoded in `auth.ts:22-26` |
+| L198: "Public forms use honeypot fields (`_gotcha`)" | No honeypot field exists anywhere (grep-negative) |
+| L198: "API route pipeline (per STANDARDS.md)" | `STANDARDS.md` contains no API-pipeline guidance; it's a non-agent security baseline |
+| L30: "Standards v1.1 enforced by standards-check.yml" | `STANDARDS.md` is v1.0 **non-agent**, whose §2 says `standards-check.yml` is *not* enforced for this repo class |
+| L145-153: `lib/csrf.ts` listed as active | `lib/csrf.ts` has **zero importers**; CSRF is generated but never validated |
+
+---
+
+## 4. Tech Debt Inventory
+
+Interest rate = how fast the item compounds if left alone.
+
+| Item | Location | Impact | Effort | Interest rate |
+|---|---|---|---|---|
+| **Live Resend API key + Supabase anon JWT committed to git** | `update-production-env.sh:12-18` | Critical — live email-send credential in history | S (rotate) / L (history scrub) | **Very high** — exposure grows every clone/fork/backup |
+| **`/api/admin/*` unprotected by middleware** | `middleware.ts:19,42` | High — auth silently bypassed for admin API | S | **High** — every new `/api/admin` route inherits the hole |
+| **Unauthenticated `/api/admin/clear-data`** | `app/api/admin/clear-data/route.ts:4-9` | High (latent) — state-change w/o auth; harmless only while store is in-memory mock | S | High — becomes data-loss the moment a real store is wired |
+| **Duplicated backend (`lib/` ↔ `api/src/lib/`)** | `lib/*`, `api/src/lib/*` | High — every fix done twice; `rate-limit` already drifted | L | **High** — divergence compounds per commit |
+| **Ungated debug routes leak env in prod** | `app/api/debug-env/route.ts:26-28`, `auth/debug`, `debug-waitlist` | Medium — partial Resend key + config disclosure | S | Medium |
+| **CSRF theater** | `lib/csrf.ts`, `app/api/csrf/route.ts` | Medium — false assurance; 0 validators | S | Low (static) |
+| **Rate limit in-memory + IP-spoofable + /16 truncation** | `lib/rate-limit.ts:16-17,50-55` | Medium — weak abuse control on email-send path | M | Medium |
+| **Deploy ships untested (no CI test gate)** | `.github/workflows/*.yml` | Medium — regressions reach prod unblocked | S | **High** — risk grows with every feature |
+| **Test theater** | `vitest.config.ts:31-34`, `e2e/*.spec.ts` | Medium — coverage gate is cosmetic; e2e self-skips | M | Medium |
+| **Dead code & tracked junk** | 37 `.bak`, `src/`, root `components/*`, `~/…Cursor` | Low each — noise tax on every review | M | Medium (accretes) |
+| **Doc drift (CLAUDE.md)** | `CLAUDE.md` | Medium — misleads every future session | M | **High** — each session acts on stale map |
+| **Two landing implementations** | `app/components/*` vs `app/components/landing/*` | Low — 2× UI surface | M | Low |
+| **`next-auth` pinned to a beta** | `package.json:82` (`5.0.0-beta.30`) | Medium — production auth on a pre-release | M | Medium |
+| **npm audit: 12 vulns (2 critical, 4 high)** | transitive (`ws`, others) | Medium | S | Medium |
+| **Docs graveyard (51 files, no ADRs)** | `docs/` | Low — decisions unrecorded/scattered | M | Medium |
+
+---
+
+## 5. Security & Compliance Posture
+
+**Blast-radius framing (read this first).** Two facts lower the *current* impact of
+the auth findings without excusing them: the admin data layer is an **in-memory
+mock array** (`lib/admin-supabase.ts:18-25`), and contact submissions are written
+only to that mock (`api/src/lib/contact.ts:33-45`), not persisted. Real PII
+(`waitlist_users`, `feedback_responses`) is written via the Supabase **anon** key
+(`api/src/lib/supabase.ts:6-15`). So the admin-panel gaps expose mock data today —
+but the *patterns* are production-dangerous the moment a real store is wired in.
+
+### 5.1 Secrets — the one that must be handled before anything else
+- **CRITICAL:** `update-production-env.sh:12-18` (tracked in git) contains a
+  real-format **Resend API key** (`re_…`, 36 chars, full send capability), the
+  **Supabase anon JWT**, and the project URL. The Resend key is a live credential
+  that can send mail from the domain. It predates the Trivy secret-scan gate, so the
+  gate never caught it (the gate only blocks *new* PRs). **Rotate the Resend key
+  now; rotate/verify the anon key + RLS; then scrub.** See `PLAN-000`.
+- **MEDIUM:** `updated-env-production.txt:19-20` commits
+  `NEXT_PUBLIC_ADMIN_USERNAME`/`_PASSWORD` defaults. `NEXT_PUBLIC_` inlines into the
+  client bundle. No current code reads them (NextAuth is used instead) — likely dead
+  config, but a committed default credential.
+- **MEDIUM:** `app/api/debug-env/route.ts:26-28` returns the Resend key's first+last
+  3 chars, ungated, on the `edge` runtime — reachable by anyone in production.
+  `auth/debug/route.ts:19-27` and `debug-waitlist/route.ts:23-28` similarly echo
+  config/env presence.
+- **Good:** real `.env*` files are untracked and gitignored (`.gitignore:34-46`);
+  `.env.1p.template` uses 1Password references.
+
+### 5.2 AuthN / AuthZ
+- **HIGH — `/api/admin/*` middleware gap.** `middleware.ts:42` matches
+  `/api/admin/:path*`, but the enforcement branch is `if (path.startsWith("/admin"))`
+  (`middleware.ts:19`). `/api/admin/...` starts with `/api`, so it falls through to
+  `NextResponse.next()`. Only routes that self-check are actually protected:
+  `email-usage/route.ts:24-28` does (`auth()` + `isAdmin`), while
+  `email-stats`, `ci-status`, and `clear-data` do **not**. See `PLAN-001`.
+- **HIGH (conditional) — client-trusted admin.** `app/admin/page.tsx:57-64` (and
+  `settings/page.tsx:23-28`, `feedback/page.tsx:56-61`) grant the admin UI when
+  `document.cookie.includes("isAdmin=true")` — not production-gated. Server
+  enforcement rests entirely on the fragile middleware. See `PLAN-001`.
+- **MEDIUM — dev bypasses.** `dev-auth/route.ts:21` accepts a hardcoded password;
+  `dev-login`, `direct-access` set non-httpOnly `isAdmin` cookies. All are
+  `NODE_ENV==="production"`-gated (correct), but hardcoded creds in source are poor
+  hygiene. The `/admin-simple/*` middleware bypass (`middleware.ts:11-15`) guards a
+  route that **does not exist** (no `app/admin-simple/`) — a latent footgun.
+- **MEDIUM — config drift.** Admin allowlist hardcoded in `auth.ts:22-26`, also
+  duplicated in `dev-login` and `auth/debug`; documented `ADMIN_EMAILS` control does
+  not exist.
+
+### 5.3 Public endpoint abuse surface
+All six Functions are `authLevel:"anonymous"`; the SWA twins are anonymous too
+(`staticwebapp.config.json:52-54`).
+- **Email-bomb / cost vector (MED-HIGH):** `POST /api/waitlist` sends a Resend
+  confirmation to an attacker-supplied address plus an admin notification
+  (`app/api/waitlist/route.ts`). The only defense (5/hr rate limit + in-memory email
+  quota) is per-instance and `x-forwarded-for`-spoofable.
+- **IDOR + missing validation (MED):** `api/src/functions/feedbackSubmit.ts:22,29`
+  is the one public endpoint that bypasses Zod — it writes a `feedback_responses`
+  row for any `waitlist_user_id` with no ownership check and an unvalidated
+  `feedbackType`.
+- **CORS contradiction:** `infra/main.bicep:123-133` restricts origins with
+  `supportCredentials:true`, but handlers hardcode `Access-Control-Allow-Origin:"*"`
+  (`waitlist.ts:12-16`). `*` + credentials is self-cancelling; net effect is
+  callable cross-origin from anywhere.
+- **CSRF absent in practice:** a full validator exists (`lib/csrf.ts:69-110`) but
+  has zero consumers; `/api/csrf` just returns a UUID with no cookie set. No
+  state-changing route validates CSRF.
+
+### 5.4 Platform headers
+- **MEDIUM — weak CSP** (`staticwebapp.config.json:19`): `script-src` allows
+  `'unsafe-inline' 'unsafe-eval'`, and `connect-src` ends in a trailing `*` that
+  nullifies the connect allowlist (exfil to any origin).
+- Otherwise solid: HSTS, `X-Frame-Options:DENY`, nosniff, Referrer-Policy,
+  Permissions-Policy, COOP/COEP/CORP.
+
+### 5.5 PII flow (collect → store → log → email)
+- **Collect:** name + email + free-text (`lib/validation.ts`).
+- **Store:** `waitlist_users`, `feedback_responses` via anon key; contact → in-memory
+  mock only (not persisted).
+- **Log:** name+email written to stdout → App Insights in multiple places
+  (`api/src/lib/supabase.ts:94-95`, `lib/email.ts:91,124,223,257,262`). No full
+  secrets logged.
+- **Email:** confirmation to submitted address; admin notification with new user's
+  name+email. Dev/DEBUG redirects mail to `delivered@resend.dev` (`lib/email.ts:100-106`).
+
+### 5.6 SOC 2 evidence opportunities
+Cheap wins that double as audit evidence: (1) the CI test/validation gate in
+`PLAN-005` = change-management evidence; (2) ADR system in `PLAN-009` = decision
+records; (3) secret rotation + history scrub in `PLAN-000` = incident-response
+evidence; (4) least-privilege pass on Supabase (move writes to service-role behind
+the server, verify RLS) = access-control evidence.
+
+---
+
+## 6. Operational Maturity
+
+- **CI/CD:** deploy-only (`.github/workflows/azure-static-web-apps.yml`) — no lint,
+  typecheck, or test runs in CI by design; validation is developer-run via
+  `scripts/validate-before-push.sh`. This is the operational soft spot: **nothing
+  mechanical stops a broken or untested change from deploying** (`PLAN-005`).
+- **Observability:** App Insights configured for prod; admin dashboard surfaces
+  email/CI stats (partly mock — `email-stats/route.ts:7-40` returns hardcoded data).
+- **Backup/recovery:** weekly repo mirror to `AIStudyPlans-Backups`
+  (`.github/workflows/backup-repository.yml`). Note: the backup copies working-tree
+  files including the committed secret — a second reason `PLAN-000` matters.
+- **Runbooks:** scattered across `docs/` as point-in-time fix logs; no consolidated
+  operational doc and no ADRs (`PLAN-009`).
+- **IaC:** `infra/main.bicep` provisions Functions/Storage/App Insights with KV
+  references — well done, but provisions the backend that serves no traffic (R-B).
+
+---
+
+## 7. Top 5 Risks (likelihood × impact)
+
+1. **Committed live Resend key is exploited** (likelihood: medium — it's in history
+   and weekly-mirrored; impact: high — domain email abuse, quota theft,
+   reputation). → `PLAN-000`.
+2. **A real data store gets wired behind the unauthenticated admin API**, turning
+   `clear-data`/admin routes into a live data-loss + PII-exposure hole (likelihood:
+   medium — it's the natural next feature; impact: high). → `PLAN-001`.
+3. **Backend duplication causes a silent prod bug** — a fix applied to one tree, not
+   the other (likelihood: high — already happened to `rate-limit`; impact: medium).
+   → `PLAN-006`.
+4. **An untested change breaks the funnel in prod** — no CI gate catches it
+   (likelihood: medium; impact: high — the funnel *is* the product). → `PLAN-005`.
+5. **`next-auth` beta or an unpatched transitive CVE breaks or exposes auth**
+   (likelihood: low-medium; impact: high). → roadmap Later (upgrade campaign) + `npm audit fix`.
+
+## Top 5 Opportunities (value ÷ effort)
+
+1. **Rotate + scrub the secret** (`PLAN-000`) — removes the one critical exposure;
+   hours of work.
+2. **Close the admin/debug attack surface** (`PLAN-001`, `PLAN-002`) — converts the
+   two HIGH auth findings to closed; small, surgical, reversible.
+3. **Add the CI validation gate** (`PLAN-005`) — makes the existing (passing) tests
+   actually protect prod; one workflow file.
+4. **Reconcile CLAUDE.md with reality** (`PLAN-004`) — compounding leverage: every
+   future session of every model inherits an accurate map.
+5. **Declare SWA canonical + delete the dead backend copy** (`PLAN-006`) — removes
+   the single largest structural liability; medium effort, high durable payoff.
+
+---
+
+## 8. Verdict
+
+**Repo health: 5 / 10.**
+
+Justification: the funnel is live and functional, and dependency hygiene is
+genuinely strong (exact pins, shrinkwrap, Trivy gate, Dependabot). But four things
+hold the score at the midpoint: (1) a **live email-send credential committed to
+git**, (2) **real authorization gaps** on the admin/debug API surface, (3) **the
+entire backend exists in two divergent copies**, one of which is documented-but-dead
+and one live-but-undocumented, and (4) **the deploy path runs no tests**. None of
+these are hard to fix — they are hygiene and consolidation, not rewrites — which is
+why the roadmap front-loads small, reversible, high-leverage moves. Fix the secret
+and the auth surface and this is a 7; consolidate the backend and add a CI gate and
+it's an 8.

--- a/docs/strategy/plans/PLAN-000-rotate-and-scrub-committed-secret.md
+++ b/docs/strategy/plans/PLAN-000-rotate-and-scrub-committed-secret.md
@@ -1,0 +1,121 @@
+# PLAN-000: Rotate & scrub the committed production secret
+**Status**: Ready
+**Effort**: S (rotate) / L (history scrub) · **Risk**: Med
+
+## Context
+This repo has a **live Resend API key** and the Supabase anon JWT committed to git
+in a tracked shell script. Anyone with repo (or backup-mirror) access can send email
+from the SchedulEd domain. The Trivy secret-scan gate
+(`.github/workflows/security-scan.yml`) did not catch it because the file predates
+the gate, which only blocks *new* PRs. The repo is also weekly-mirrored to
+`AIStudyPlans-Backups` (`.github/workflows/backup-repository.yml`), so the secret is
+replicated. This is the only actively-exploitable finding in the review — do it
+first, before any other plan.
+
+Do **not** paste the secret values into any file, commit message, PR, or chat. Refer
+to them by location only.
+
+## Goal / Non-goals
+- **Goal:** Make the committed credential worthless (rotate) and remove it from the
+  working tree so no future clone re-exposes a live secret.
+- **Goal:** Decide and document whether to rewrite history.
+- **Non-goal:** Changing how the app reads secrets at runtime (it already uses
+  env/Key Vault correctly). This plan does not touch `lib/email.ts` or KV wiring
+  beyond updating the rotated value.
+
+## Current state
+Tracked files containing secrets (verified via `git grep`):
+- `update-production-env.sh:12` — Supabase project URL
+- `update-production-env.sh:13` — Supabase **anon** JWT (`eyJ…`, `role:anon`)
+- `update-production-env.sh:18` — **Resend API key** (`re_…`, 36 chars, live send)
+- `updated-env-production.txt:19-20` — `NEXT_PUBLIC_ADMIN_USERNAME` /
+  `NEXT_PUBLIC_ADMIN_PASSWORD` (default `admin`/`adminpass`; unused by current
+  NextAuth code but committed)
+
+Also verify (may be a placeholder, confirm before acting):
+- `scripts/direct-env-setup.sh:8` — a `re_REP…`-prefixed string that looks like
+  `re_REPLACE...`; if it is a placeholder, leave it; if it is a real key, treat it
+  like `update-production-env.sh`.
+
+Runtime already reads `RESEND_API_KEY` from env / Key Vault (`lib/email.ts`), so
+rotating the value in Resend + Key Vault + SWA settings is transparent to the code.
+
+## Target state
+- The Resend key committed here is **revoked**; a new key is issued and stored only
+  in Key Vault (`aistudyplansvault`, secret `resend-api-key`) and referenced by the
+  SWA/Functions app settings.
+- `update-production-env.sh` and `updated-env-production.txt` are removed from the
+  working tree (they are operational scratch, not needed in-repo), and the secret
+  pattern is gitignored so they cannot be re-added.
+- A decision on history rewrite is recorded (see Steps 4–5).
+
+## Steps
+1. **Rotate the Resend key (mandatory, first).** This neutralizes the exposure
+   regardless of history.
+   - In the Resend dashboard, **revoke** the key whose value is in
+     `update-production-env.sh:18`, and create a replacement.
+   - Store the new key in Key Vault: `az keyvault secret set --vault-name
+     aistudyplansvault --name resend-api-key --value <NEW_KEY>` (run interactively by
+     the operator via `! az …` so the value never lands in a tool log).
+   - Confirm the SWA and Functions app settings reference the KV secret (they already
+     do per `CLAUDE.md` "KV secrets"); no code change needed. Verify with a test send
+     (`npm run test:email` or a waitlist signup to a test address).
+2. **Rotate/verify the Supabase anon key + RLS.** The anon key is public-by-design
+   (it ships in the client bundle), so its exposure is lower severity — but the repo
+   ships `fix-supabase-rls.md` implying RLS was loosened. In the Supabase dashboard:
+   verify RLS on `waitlist_users` and `feedback_responses` allows anonymous
+   **INSERT only** (no anonymous SELECT of PII). Rotating the anon key is optional;
+   fixing RLS is the real control. Record the RLS state.
+3. **Remove the secret-bearing scratch files from the working tree** and gitignore
+   them:
+   - `git rm update-production-env.sh updated-env-production.txt`
+   - If `scripts/direct-env-setup.sh:8` is confirmed a real key, `git rm` it too;
+     if placeholder, leave it.
+   - Add to `.gitignore`: `update-production-env.sh`, `updated-env-production.txt`,
+     `*-env-production.txt`.
+   - Commit: `chore(security): remove committed env scratch files (secret rotated)`.
+4. **Decide on history rewrite (escalate to human).** Rewriting history is the only
+   way to remove the *old* value from git history, but it requires a force-push to
+   `main`, which is blocked by branch protection (`STANDARDS.md:107` —
+   `allow_force_pushes=false`) and would break the backup mirror's fast-forward.
+   **Pre-resolved recommendation:** because the key is rotated (Step 1), the historic
+   value is already worthless, so a history rewrite is *defense-in-depth, not
+   urgent*. Recommend scrubbing history only if the repo will ever go public
+   (`STANDARDS.md:136-141`) or if policy requires no secrets in history. **This is
+   the one human decision in this plan** — the operator must choose.
+5. **If (and only if) the human approves a history rewrite:**
+   - Temporarily relax branch protection: allow force-push on `main`.
+   - `git filter-repo --path update-production-env.sh --path updated-env-production.txt --invert-paths`
+     (install `git-filter-repo`; do **not** use the deprecated `filter-branch`).
+   - Force-push, then re-run the backup workflow (it force-pushes the mirror anyway —
+     `backup-repository.yml` uses `git push -f`, so the mirror self-heals).
+   - Re-enable branch protection.
+   - Notify any other clone holders to re-clone.
+
+## Security & compliance notes
+- **Least privilege:** the new Resend key should be scoped to sending only, if Resend
+  supports scoped keys. Store only in Key Vault; never in a tracked file.
+- **Audit trail:** record the rotation (date, who, old-key-revoked) — this is SOC 2
+  incident-response evidence. A one-line ADR (`PLAN-009`) is a good home.
+- **Data handling:** Step 2's RLS verification is the actual PII control; do not skip
+  it because the anon key is "public."
+
+## Validation
+- `git ls-files | grep -E 'update-production-env|updated-env-production'` → **no
+  output** (files untracked).
+- `git grep -nE 're_[A-Za-z0-9_-]{20,}'` → returns only confirmed placeholders (e.g.
+  `re_REPLACE…`), no live key.
+- Resend dashboard shows the old key **revoked** and a new key active.
+- A test waitlist signup to a throwaway address delivers a confirmation email (proves
+  the rotated key is wired correctly).
+- If history was scrubbed: `git log --all --full-history -- update-production-env.sh`
+  → empty.
+
+## Rollback
+- Working-tree removal (Step 3) is reversible via `git revert` of the removal commit
+  — but do **not** revert it, since that re-adds the (now-revoked, worthless) file.
+- Key rotation is not "rolled back"; if the new key misbehaves, issue another key and
+  update KV. The old key stays revoked permanently.
+- History rewrite (Step 5) is the irreversible step; the pre-rewrite state exists in
+  the backup mirror until its next weekly run, and locally in reflogs — but treat
+  Step 5 as one-way and only run it with human sign-off.

--- a/docs/strategy/plans/PLAN-001-close-admin-api-authorization-gap.md
+++ b/docs/strategy/plans/PLAN-001-close-admin-api-authorization-gap.md
@@ -1,0 +1,117 @@
+# PLAN-001: Close the `/api/admin/*` authorization gap
+**Status**: Ready
+**Effort**: S · **Risk**: Low
+
+## Context
+The admin API is not actually protected. `middleware.ts` declares a matcher that
+*includes* `/api/admin/:path*`, but the enforcement logic only fires for
+`/admin/*` page routes. `/api/admin/*` requests start with `/api`, miss every
+branch, and fall through to `NextResponse.next()` — reaching the handler
+unauthenticated. Only handlers that run their own `auth()` check are protected; most
+don't. The SWA route config also marks `/api/*` as anonymous
+(`staticwebapp.config.json:52-54`), so there is no platform-level backstop.
+
+Impact is limited *today* only because the affected routes return mock data or reset
+an in-memory array (`lib/admin-supabase.ts:18-25`). But the pattern means the next
+admin route a developer adds ships unauthenticated, and `clear-data` is already an
+unauthenticated state-change. Also, the admin *pages* trust a client-settable
+`isAdmin` cookie for their UI gate, which is weak defense-in-depth.
+
+## Goal / Non-goals
+- **Goal:** Every `/api/admin/*` route requires an authenticated admin (server-side),
+  via both a fixed middleware and a per-route guard (defense-in-depth).
+- **Goal:** Remove the client-trusted `isAdmin` cookie/localStorage as an *authority*
+  (it may remain as a UI hint only if server enforcement is solid).
+- **Non-goal:** Redesigning the auth provider or session model — `auth.ts` is sound.
+- **Non-goal:** Building real admin data. This plan secures the surface; wiring real
+  data is deferred (see `ROADMAP.md` anti-goals).
+
+## Current state
+- `middleware.ts:9-40`: branches for `/admin-simple` (bypass, guards a nonexistent
+  route), `/api/auth` (allow), `/admin` (enforce). No branch handles `/api/admin`.
+  `middleware.ts:42` matcher: `["/admin/:path*", "/api/admin/:path*", "/admin-simple/:path*"]`.
+- `app/api/admin/clear-data/route.ts:4-9` — `POST`, no `auth()` check, calls
+  `clearAllFeedbackData()`.
+- `app/api/admin/email-stats/route.ts`, `ci-status/route.ts` — no `auth()` check
+  (return mock data).
+- `app/api/admin/email-usage/route.ts:24-28,106-110` — **correct** pattern
+  (`auth()` + `session.user.isAdmin` → 401). Use as the template.
+- `app/api/admin/dev-auth`, `dev-login`, `direct-access` — `NODE_ENV==="production"`
+  gated; leave their gates but they will also gain the middleware guard.
+- Client-trust: `app/admin/page.tsx:57-64`, `app/admin/settings/page.tsx:23-28`,
+  `app/admin/feedback/page.tsx:56-61` grant access on
+  `document.cookie.includes("isAdmin=true")`, not production-gated.
+
+## Target state
+- `middleware.ts` enforces admin auth for `/api/admin/*` (returns JSON 401/403, not a
+  redirect, since these are API routes) **and** removes the dead `/admin-simple`
+  bypass.
+- `email-stats`, `ci-status`, `clear-data` each call `auth()` and 401 on non-admin,
+  matching `email-usage`.
+- Admin page components no longer treat a raw `isAdmin` cookie as proof of admin;
+  they rely on the server session (`useSession`) they already import.
+
+## Steps
+1. **Fix `middleware.ts`.** Replace the enforcement so it covers both page and API
+   admin paths, and remove the `/admin-simple` bypass block (`middleware.ts:11-15`)
+   and its matcher entry.
+   - Compute `const isApi = path.startsWith("/api/admin")`.
+   - Guard condition becomes: `if (path.startsWith("/admin") || isApi)`.
+   - Inside: if no `request.auth` → for API return
+     `NextResponse.json({ error: "Unauthorized" }, { status: 401 })`; for pages keep
+     the existing redirect to `/api/auth/signin`.
+   - If `request.auth` but `!request.auth.user?.isAdmin` → for API return
+     `NextResponse.json({ error: "Forbidden" }, { status: 403 })`; for pages keep the
+     existing 403 `NextResponse`.
+   - Update `config.matcher` to `["/admin/:path*", "/api/admin/:path*"]` (drop
+     `/admin-simple/:path*`).
+2. **Add per-route guards (defense-in-depth)** to the three unprotected routes, using
+   the exact shape from `email-usage/route.ts:24-28`:
+   ```ts
+   import { auth } from "@/auth";
+   // at the top of the handler:
+   const session = await auth();
+   if (!session?.user?.isAdmin) {
+     return NextResponse.json({ error: "Unauthorized - Admin access required" }, { status: 401 });
+   }
+   ```
+   Apply to: `app/api/admin/clear-data/route.ts` (`POST`),
+   `app/api/admin/email-stats/route.ts` (`GET`),
+   `app/api/admin/ci-status/route.ts` (`GET`). Keep imports minimal to satisfy
+   `no-unused-vars` (error-level lint).
+3. **De-authorize the client cookie.** In `app/admin/page.tsx`,
+   `app/admin/settings/page.tsx`, `app/admin/feedback/page.tsx`, remove the
+   `document.cookie.includes("isAdmin=true") || localStorage…` branch from the access
+   decision. These components already have `useSession`; gate the UI on
+   `session?.user?.isAdmin`. The cookie may remain set by the (prod-gated) dev
+   endpoints for local convenience, but it must not be the authority. If a component
+   currently *only* uses the cookie and has no `useSession`, add the
+   `useSession()`/`SessionProvider` usage (the provider is already in the tree via
+   `app/providers.tsx`).
+4. **Verify the dev endpoints keep their prod gate** (no change expected):
+   `dev-auth`, `dev-login`, `direct-access` still return 403 when
+   `NODE_ENV==="production"`.
+
+## Security & compliance notes
+- **Least privilege:** admin API now fails closed (401/403 by default) at two layers.
+- **Audit trail:** `email-usage` already logs the acting admin email on mutation
+  (`route.ts:124`); consider the same one-liner in `clear-data` when it does real
+  work later. Not required now.
+- **No secrets touched.** This is pure authz wiring.
+
+## Validation
+- `npm run typecheck && npm run lint` clean (watch `no-unused-vars`).
+- `npm run build` succeeds.
+- Local manual check with dev server (`npm run dev`):
+  - `curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:3000/api/admin/clear-data`
+    → **401** (was 200).
+  - `curl … /api/admin/email-stats` → **401** unauthenticated.
+  - With a valid admin session cookie, the same calls → 200.
+- Add a middleware/authz unit or e2e test asserting an unauthenticated
+  `/api/admin/clear-data` POST returns 401 (feeds `PLAN-008`; at minimum add it here
+  as the regression guard for this fix).
+- Existing `npm test` suite still passes (54 tests).
+
+## Rollback
+`git revert` the commit. The change is additive guards + a matcher edit; reverting
+restores prior behavior with no data or config migration.

--- a/docs/strategy/plans/PLAN-002-remove-production-debug-endpoints.md
+++ b/docs/strategy/plans/PLAN-002-remove-production-debug-endpoints.md
@@ -1,0 +1,68 @@
+# PLAN-002: Remove production debug endpoints
+**Status**: Ready
+**Effort**: S · **Risk**: Low
+
+## Context
+Several `/api/*debug*` routes ship to production ungated and disclose environment
+and configuration details. The worst returns the first and last 3 characters of the
+live Resend API key. These routes are not covered by the `middleware.ts` matcher, so
+they are fully public. They exist for one-time troubleshooting that is long over; the
+information they leak aids an attacker and provides no ongoing value.
+
+## Goal / Non-goals
+- **Goal:** No production endpoint discloses secrets, secret fragments, env-var
+  presence, or auth configuration.
+- **Non-goal:** Removing legitimate operational endpoints. `/api/health` stays (it
+  returns only status/version). `/api/email-config` is already dev-gated for its
+  detailed branch and returns only a boolean otherwise — keep it.
+
+## Current state
+Ungated / disclosing (verified by reading each file):
+- `app/api/debug-env/route.ts:26-28` — returns Resend key prefix+suffix, email
+  config; `runtime="edge"`; **no** prod gate.
+- `app/api/debug-waitlist/route.ts:23-28` — echoes env presence (supabase/resend/
+  email_from); `runtime="edge"`; **no** prod gate.
+- `app/api/auth/debug/route.ts:5-27` — echoes Azure AD / NextAuth config presence,
+  `NEXTAUTH_URL` value, `NODE_ENV`, a hardcoded admin email; **no** prod gate.
+- `app/api/debug-email/route.ts:12` — gated by
+  `NODE_ENV==="development" || DEBUG_EMAIL==="true"` (so it can be turned on in prod
+  via the `DEBUG_EMAIL` flag); logs env details.
+
+Keep as-is:
+- `app/api/health/route.ts` — status/version only.
+- `app/api/email-config/route.ts` — boolean-only outside development.
+
+## Target state
+- `debug-env`, `debug-waitlist`, `auth/debug` route directories deleted.
+- `debug-email` either deleted or hard-gated to `NODE_ENV==="development"` only
+  (remove the `DEBUG_EMAIL` prod escape hatch). **Pre-resolved choice: delete it** —
+  email delivery is confirmed working (its own header comment says to remove it once
+  confirmed), and `PLAN-008` will add a proper email-path test.
+
+## Steps
+1. `git rm -r app/api/debug-env app/api/debug-waitlist app/api/auth/debug app/api/debug-email`.
+2. Grep for any references to these routes so nothing 404s silently:
+   `git grep -nE "debug-env|debug-waitlist|auth/debug|debug-email"` across
+   `app/`, `components/`, `lib/`, `e2e/`, `scripts/`, `docs/`. Expected: only doc
+   mentions. Remove/adjust any live `fetch()` to them (none expected — these were
+   manual-curl endpoints).
+3. If any `staticwebapp.config.json` route rule names these paths, remove it (none
+   expected — its rules are generic `/api/*`).
+4. Leave `health` and `email-config` untouched.
+
+## Security & compliance notes
+- Removes a partial-secret disclosure and config-enumeration surface. Complements
+  `PLAN-000` (rotating the key makes the leaked fragment worthless; deleting the
+  route removes the leak entirely).
+- No least-privilege or data-handling change beyond deletion.
+
+## Validation
+- `git grep -nE "debug-env|debug-waitlist|auth/debug|debug-email"` returns no
+  code references (doc-only mentions are acceptable and handled by `PLAN-004`/`009`).
+- `npm run build` succeeds (no dangling imports).
+- Local: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/debug-env`
+  → **404**.
+- `curl … /api/health` → 200 (unchanged).
+
+## Rollback
+`git revert` the deletion commit restores the routes verbatim. No state involved.

--- a/docs/strategy/plans/PLAN-003-purge-dead-code-and-tracked-junk.md
+++ b/docs/strategy/plans/PLAN-003-purge-dead-code-and-tracked-junk.md
@@ -1,0 +1,104 @@
+# PLAN-003: Purge dead code & tracked junk
+**Status**: Ready
+**Effort**: M · **Risk**: Low
+
+## Context
+The repo carries heavy dead weight that taxes every review, grep, and future
+session: 37 tracked `.bak` files, an untouched create-next-app boilerplate at
+`src/app/`, ~16 never-imported duplicate components, and assorted committed junk
+(editor settings inside a literal `~` directory, lockfile backups, zero-byte logs).
+None of it runs. Deleting it is the single cheapest way to raise the
+signal-to-noise of the whole codebase, and git is a perfect rollback.
+
+This plan deletes **only unambiguously dead files**. It deliberately does **not**
+touch: the Azure Functions backend (`api/`, see `PLAN-006`), `lib/csrf.ts` +
+`app/api/csrf` (see `PLAN-007`), or the second landing page (`ROADMAP.md` L-3).
+Those need decisions, not just deletion.
+
+## Goal / Non-goals
+- **Goal:** Remove dead files with zero runtime effect, verified before each Tier-2
+  deletion.
+- **Non-goal:** Refactoring, renaming, or "improving" any live code. Deletion only.
+- **Non-goal:** Removing anything that requires an architectural decision (backend,
+  CSRF, landing pages).
+
+## Current state
+Confirmed via the architecture recon (import-graph grep):
+
+**Tier 1 — delete unconditionally (100% dead, no possible importer):**
+- All 37 `.bak` files: `app/components/*.bak` (14), `app/*.bak` +
+  `app/context/ThemeContext.tsx.bak`, `app/feedback/page.tsx.bak`,
+  `app/landing/page.tsx.bak`, `components/*.bak` (15), `src/app/layout.tsx.bak`.
+- `src/` entirely — `src/app/{page.tsx,layout.tsx,globals.css,favicon.ico}` is
+  create-next-app boilerplate ("Get started by editing src/app/page.tsx"); `src/utils/helpers.js`
+  imported by nothing. Next.js ignores `src/app/` because root `app/` wins.
+- Committed junk: `~/Library/Application Support/Cursor/User/settings.json` (a literal
+  `~` dir), `package-lock.json.backup`, `package.json.backup`, `.dependency-status.json`,
+  `.security-audit.json`, `test_file.ts`, `end_line.txt`, `test-backup.txt`,
+  `aistudyplans-launchd_backup.log`, `aistudyplans-launchd_backup_error.log`,
+  `swa-deploy/` (stale deploy staging), `saved/` (snapshot dump).
+
+**Tier 2 — delete after a per-path grep confirms zero importers:**
+- Root `components/` dead duplicates: `CTASection.tsx`, `DashboardSidebar.tsx`,
+  `DashboardLayout.tsx`, `FeaturesGrid.tsx`, `HowItWorksCards.tsx`, `Stats.tsx`,
+  `StatsShowcase.tsx`, `StudyPlanPreview.tsx`, `StudyPlanCard.tsx`, `StudyTimer.tsx`,
+  `Testimonials.tsx`, `TodoApp.tsx`, `Waitlist.tsx`, `FAQ.tsx`, `HowItWorks.tsx`,
+  `admin/FeedbackChart.tsx`.
+- `app/components/AnimatedFeature.tsx`, `app/components/ParallaxBackground.tsx`.
+- Pages-Router remnant: `pages/_app.js` + root `styles/globals.css`,
+  `styles/animations.css` (live CSS is `app/globals.css`; `app/styles/` is empty).
+
+**Keep (live — do NOT delete):** `components/ErrorBoundary.tsx`,
+`components/InteractiveStudyPlanDemo.tsx`, `components/auth/Provider.tsx`,
+`components/admin/{EmailStatusChecker,FeedbackFilters,FeedbackTable}.tsx`.
+
+## Target state
+Tier 1 and grep-confirmed Tier 2 files removed; build, typecheck, lint, and tests
+still green; no route or component behavior changed.
+
+## Steps
+1. **Tier 1 deletion.**
+   - `git rm` all 37 `.bak` files. Generate the list with
+     `git ls-files '*.bak'` and remove exactly those.
+   - `git rm -r src/`.
+   - `git rm -r "~"` (the literal tilde directory) and the junk files listed above.
+   - `git rm -r swa-deploy saved`.
+2. **Prevent recurrence:** confirm `.gitignore` already ignores `*.bak`? It does
+   **not** — add `*.bak` and `*.backup` to `.gitignore` so these can't be re-added.
+3. **Tier 2 deletion — verify each before removing.** For every Tier-2 path, run a
+   consumer grep and delete only if it returns nothing outside the file itself and
+   `.bak` files:
+   ```
+   git grep -n "ComponentNameOrBasename" -- 'app/**' 'components/**' 'lib/**' \
+     ':!*.bak' | grep -v 'components/<the-file-itself>'
+   ```
+   Example: for `components/FAQ.tsx`, confirm the only live `FAQ` import is
+   `app/components/FAQ` (used by `app/page.tsx`), not `components/FAQ`. Delete the
+   root `components/FAQ.tsx` only if nothing imports `@/components/FAQ`.
+   - For `pages/_app.js` + `styles/`: confirm nothing imports from `../styles/` or
+     `@/styles/` except `pages/_app.js` itself, then `git rm -r pages styles`.
+4. **Rebuild the type build info is not tracked** (`.gitignore` covers
+   `*.tsbuildinfo`); no action.
+5. Commit in two commits (Tier 1, then Tier 2) so a bisect can isolate any
+   surprise.
+
+## Security & compliance notes
+- Removes committed editor config and lockfile backups (minor supply-chain/noise
+  hygiene). No secrets are in these Tier-1/2 files (the secret files are handled by
+  `PLAN-000` — do that first so this plan doesn't touch them).
+- None of these files are in the request path; deletion cannot change runtime authz
+  or data handling.
+
+## Validation
+- `npm run typecheck` clean (proves no live code imported a deleted file — TS would
+  error on a missing module).
+- `npm run lint` clean.
+- `npm run build` succeeds.
+- `npm test` → still 54 passing (no test imports a deleted path; if one does, it was
+  testing dead code — remove that test and note it).
+- `git ls-files '*.bak' | wc -l` → **0**.
+- `git ls-files | grep -E '~/|\.backup$|launchd_backup'` → **empty**.
+
+## Rollback
+Every deletion is a `git revert` away. Because Tier 1 and Tier 2 are separate
+commits, a surprise in Tier 2 can be reverted without losing the Tier-1 cleanup.

--- a/docs/strategy/plans/PLAN-004-reconcile-claude-md-with-reality.md
+++ b/docs/strategy/plans/PLAN-004-reconcile-claude-md-with-reality.md
@@ -1,0 +1,97 @@
+# PLAN-004: Reconcile CLAUDE.md with reality
+**Status**: Ready
+**Effort**: M · **Risk**: Low
+
+## Context
+`CLAUDE.md` is the first file every future Claude session reads. Several of its
+load-bearing claims are wrong, so every session starts from a false map — describing
+an architecture that isn't running, a security control that doesn't exist, and a
+standards classification that contradicts `STANDARDS.md`. Fixing it is
+low-effort and compounds across every future session of every model.
+
+Run this **after** `PLAN-003` (dead-code purge) so the corrected doc describes the
+cleaned tree, and **after** `PLAN-000/001/002` so it can state the post-fix security
+posture.
+
+## Goal / Non-goals
+- **Goal:** `CLAUDE.md` accurately describes the running system, the real data flow,
+  the real admin-auth control, and the correct standards classification.
+- **Non-goal:** Rewriting the whole file or changing its structure. Targeted edits to
+  the drifted claims only.
+- **Non-goal:** Making code match the docs (that's `PLAN-006`). Here, docs bend to
+  code.
+
+## Current state — the drifted claims (each verified)
+1. `CLAUDE.md:112-198` — describes waitlist/contact/feedback as served by the Azure
+   Functions backend via CORS. **Reality:** the frontend calls the SWA Next.js routes
+   (`app/hooks/useWaitlistForm.ts:133-150` → `${NEXT_PUBLIC_APP_URL}/api/waitlist`).
+   Functions serves no production traffic.
+2. `CLAUDE.md:96-102` — calls `src/app/` a "secondary/legacy entry point … backup
+   layout." **Reality:** it was create-next-app boilerplate, now deleted by
+   `PLAN-003`.
+3. `CLAUDE.md:166` — "Admin access controlled by `ADMIN_EMAILS` env var." **Reality:**
+   `ADMIN_EMAILS` is read by no code; the allowlist is hardcoded in `auth.ts:22-26`.
+4. `CLAUDE.md:198` — "Public forms use honeypot fields (`_gotcha`)." **Reality:** no
+   honeypot exists.
+5. `CLAUDE.md:198` — "API route pipeline (per STANDARDS.md)." **Reality:**
+   `STANDARDS.md` has no such guidance.
+6. `CLAUDE.md:30` — "Herculean Ecosystem Standards v1.1 (enforced by
+   standards-check.yml)." **Reality:** `STANDARDS.md` is the **non-agent v1.0**
+   standard whose §2 says `standards-check.yml`, root `STANDARDS.md`, and root
+   `CLAUDE.md` are *not* gating for this repo class.
+7. `CLAUDE.md:145-153` — lists `lib/csrf.ts` as active. **Reality:** zero importers;
+   CSRF is generated but never validated (resolved by `PLAN-007`).
+
+## Target state
+Each claim above is corrected to describe reality. The API-architecture section
+states plainly: **the Azure SWA Next.js API routes are canonical and serve all
+production traffic; the `api/` Azure Functions backend exists but is not in the
+request path and is slated for decommission** (points to `PLAN-006` / `ROADMAP.md`
+L-1). The standards section states the repo's actual classification (non-agent, per
+`STANDARDS.md`) and notes the historical agent-repo machinery still present.
+
+## Steps
+1. **API architecture (CLAUDE.md ~112-198):** rewrite the "Split Architecture" and
+   "Service Layer & Data Flow" subsections to describe the running system:
+   - Waitlist/contact/feedback/health are served by `app/api/*` on the SWA.
+   - The data flow is: Client → SWA → Next.js route → `lib/*` → Supabase/Resend.
+   - Add a one-line note: "An `api/` Azure Functions backend exists as a parallel,
+     currently-unused implementation; it is frozen and slated for decommission — see
+     `docs/strategy/` and `PLAN-006`." Do not describe it as the active backend.
+2. **Remove the honeypot claim** (`:198`) — no `_gotcha` field exists. If desired as
+   a *future* control, phrase it as a TODO, not a statement of fact. (Pre-resolved:
+   just remove it; a honeypot can be added later if spam warrants.)
+3. **Admin auth (`:166`):** change to "Admin access is controlled by a hardcoded
+   allowlist in `auth.ts`; `ADMIN_EMAILS` is documented but not currently wired." If
+   `PLAN-001` or a follow-up wires `ADMIN_EMAILS`, update to match — but state today's
+   truth now.
+4. **Dual app directory section (`:96-102`):** remove — `src/app/` no longer exists
+   after `PLAN-003`. Replace with a one-line note that `app/` is the sole app dir.
+5. **Standards section (`:30`):** correct to reflect `STANDARDS.md` (non-agent v1.0).
+   State that root `STANDARDS.md`/`CLAUDE.md`/`standards-check.yml` are present for
+   historical/convenience reasons but are not gating for this repo class per
+   `STANDARDS.md:25-35`. Escalate the underlying question to the human as a note:
+   "Decide whether this repo should be reclassified as an agent repo or have the
+   agent-only machinery removed" — this is a fleet-policy call, not an edit.
+6. **`lib/` list (`:145-153`):** mark `csrf.ts` per the outcome of `PLAN-007`. If
+   `PLAN-004` runs before `PLAN-007`, note "CSRF token generation exists but is not
+   currently validated on any route (under review — see `PLAN-007`)."
+7. Cross-check every remaining path in `CLAUDE.md` still resolves after `PLAN-003`
+   (e.g. component locations). Fix any now-stale path.
+
+## Security & compliance notes
+- No code or secret change. Accurate docs are themselves a compliance asset (they
+  prevent a future session from, e.g., adding an unauthenticated admin route believing
+  the middleware protects it).
+
+## Validation
+- Manual diff review: each of the 7 claims above now matches code. Spot-check with
+  grep, e.g. `git grep -n "ADMIN_EMAILS"` returns no code hits, confirming claim 3's
+  correction.
+- Every file path referenced in `CLAUDE.md` exists:
+  `grep -oE '\b[a-zA-Z0-9_./-]+\.(ts|tsx|mjs|json|bicep|sh)\b' CLAUDE.md` → spot-check
+  each resolves (allow for the intentional `api/` mention).
+- No automated test; this is a documentation-accuracy plan. The proof is the diff.
+
+## Rollback
+`git revert`. Documentation-only.

--- a/docs/strategy/plans/PLAN-005-add-ci-validation-gate.md
+++ b/docs/strategy/plans/PLAN-005-add-ci-validation-gate.md
@@ -1,0 +1,112 @@
+# PLAN-005: Add a CI validation gate
+**Status**: Ready
+**Effort**: S · **Risk**: Low
+
+## Context
+CI is deploy-only: `azure-static-web-apps.yml` builds and deploys on push to `main`
+and runs **no** lint, typecheck, or tests (its header comment says validation "runs
+locally before push"). The only enforcement is the developer running
+`scripts/validate-before-push.sh` by hand. So a broken or untested change reaches
+production if a developer forgets, and there is no mechanical gate. The unit suite
+already exists and passes (54 tests, ~8s) — it just never runs in CI. This plan makes
+the existing, passing tests actually protect the deploy, for one workflow file.
+
+This is intentionally *additive* and respects the repo's "validate locally" ethos: it
+adds a fast PR gate, it does not move deploy logic or add e2e (deferred to
+`PLAN-008`).
+
+## Goal / Non-goals
+- **Goal:** Every PR to `main` runs lint + typecheck + unit tests + build, and a
+  failure blocks merge.
+- **Non-goal:** Running Playwright e2e in CI (browsers + dev server; also currently
+  self-skipping theater — `PLAN-008` fixes that first).
+- **Non-goal:** Changing the deploy workflow or the local `validate` script.
+- **Non-goal:** Enforcing coverage thresholds — they are zeroed under `CI` today
+  (`vitest.config.ts:31`); that's a `PLAN-008` concern.
+
+## Current state
+- `.github/workflows/azure-static-web-apps.yml` — build + deploy, no tests.
+- `.github/workflows/standards-check.yml` — checks required files / no-`.env`, not
+  tests.
+- `.github/workflows/security-scan.yml` — Trivy, not tests.
+- `.github/workflows/dependency-checks.yml` — dep validation, not tests.
+- `package.json:15-18` — `lint`, `typecheck`, `test` scripts exist and pass.
+- `scripts/validate-before-push.sh` — the manual gate (lint → typecheck → test →
+  build).
+
+## Target state
+A new `.github/workflows/validate.yml` runs on `pull_request` to `main` (and on
+`push` to `main` as a backstop), executing lint, typecheck, unit tests, and build on
+Node 20.19.1. Branch protection is updated (operator step) to require it.
+
+## Steps
+1. **Create `.github/workflows/validate.yml`:**
+   ```yaml
+   name: Validate
+   on:
+     pull_request:
+       branches: [main]
+     push:
+       branches: [main]
+     workflow_dispatch:
+   permissions:
+     contents: read
+   concurrency:
+     group: validate-${{ github.ref }}
+     cancel-in-progress: true
+   jobs:
+     validate:
+       runs-on: ubuntu-latest
+       timeout-minutes: 15
+       steps:
+         - uses: actions/checkout@v6
+         - uses: actions/setup-node@v6
+           with:
+             node-version: "20.19.1"
+             cache: "npm"
+         - run: npm ci --legacy-peer-deps
+         - run: npm run lint
+         - run: npm run typecheck
+         - run: npm test
+         - run: npm run build
+           env:
+             NEXT_PUBLIC_SUPABASE_URL: https://placeholder-for-build.supabase.co
+             NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key-for-build
+   ```
+   Rationale for pinned choices: Node `20.19.1` matches `.nvmrc` and the deploy
+   workflow; `--legacy-peer-deps` matches the deploy workflow (`@types/node`/vite peer
+   conflict per `CLAUDE.md`); the build env placeholders mirror `ci-build.sh:20-27` so
+   the build doesn't fail on missing Supabase vars. `npm test` = `vitest run`
+   (`package.json:18`).
+2. **Order the checks** lint → typecheck → test → build so the cheapest failure
+   surfaces first (fail-fast; steps stop on first non-zero exit).
+3. **Make it a required check (operator step, human-run).** Per `STANDARDS.md:107`
+   branch protection currently sets `required_status_checks=null`. To gate merges,
+   the operator runs:
+   ```bash
+   gh api -X PUT repos/herculeanfit1/AIStudyPlans/branches/main/protection/required_status_checks \
+     -F strict=true -f 'contexts[]=validate'
+   ```
+   Flag this as the human step — the workflow lands first, is observed green on a PR,
+   then is marked required (mirrors `STANDARDS.md:97-98`'s "require the gate once it
+   runs cleanly for ~1 week" pattern).
+4. **Leave `standards-check.yml`, `security-scan.yml`, `dependency-checks.yml`
+   untouched** — they cover different concerns and already run.
+
+## Security & compliance notes
+- `permissions: contents: read` only — least privilege for the workflow token.
+- No secrets needed (build uses public placeholders; unit tests run in mock mode).
+- This gate is **change-management evidence for SOC 2** — every merge to `main` now
+  has an automated verification record.
+
+## Validation
+- Open a scratch PR that intentionally breaks a type (e.g. add `const x: number =
+  "s";` in a temp file). The `validate` job fails at the typecheck step and the PR
+  shows a failing check. Revert the break; the check goes green.
+- On a clean PR, `validate` completes green in a few minutes.
+- After Step 3, a failing `validate` blocks the merge button.
+
+## Rollback
+Delete `.github/workflows/validate.yml` and, if it was made required, revert the
+branch-protection change (`gh api -X PUT … required_status_checks -F 'contexts[]='`
+to clear, or set back to null). No product code involved.

--- a/docs/strategy/plans/PLAN-006-declare-swa-canonical-freeze-functions-backend.md
+++ b/docs/strategy/plans/PLAN-006-declare-swa-canonical-freeze-functions-backend.md
@@ -1,0 +1,113 @@
+# PLAN-006: Declare SWA API routes canonical; freeze the Functions backend
+**Status**: Ready
+**Effort**: M · **Risk**: Med
+
+## Context
+The repo has two full backend implementations of the same endpoints:
+- **SWA Next.js routes** (`app/api/*` + `lib/*`) — **the ones the frontend actually
+  calls in production** (`app/hooks/useWaitlistForm.ts:133-150` posts to
+  `${NEXT_PUBLIC_APP_URL}/api/waitlist`; contact/feedback likewise).
+- **Standalone Azure Functions** (`api/src/*`) — deployed as `func-btai-asp-prod`,
+  but **called by no frontend code**. Verified: no `fetch` in the app targets the
+  Functions host; `NEXT_PUBLIC_APP_URL` is the SWA domain, not the Functions URL.
+
+Nine `lib/` files are byte-identical across the two trees; `rate-limit.ts` has
+already diverged 143 lines. This duplication is the review's #1 structural risk: every
+fix must be done twice or the copies rot, and one copy is dead.
+
+**This plan resolves the direction and stops the bleed. It does not tear down cloud
+infrastructure** — that is `ROADMAP.md` L-1, gated on confirming traffic, because
+deleting live Azure resources is the one irreversible move in this whole review.
+
+## The decision (pre-resolved — do not re-litigate)
+**The Azure SWA Next.js API routes are canonical. The `api/` Azure Functions backend
+is frozen and slated for decommission.**
+
+Why this direction and not the reverse (migrating the frontend onto Functions, which
+is what `CLAUDE.md` *documents*):
+1. The SWA routes already serve 100% of production traffic. Consolidating toward the
+   running system is lower-risk than repointing live traffic onto the untested
+   Functions copy (`api/` has **zero tests** — no test script in `api/package.json`).
+2. SWA managed functions comfortably handle waitlist-funnel volume; the Functions app
+   is over-provisioned for the load.
+3. The documented rationale for the split (`CLAUDE.md:130-134`) is only that NextAuth
+   must stay on SWA. Under "SWA canonical," *everything* stays on SWA, which fully
+   satisfies that constraint — the split it argues for isn't needed.
+
+**Assumption stated (cannot see from the repo):** that there is no business/cost
+reason the Functions backend was chosen (e.g., a plan to share it with another
+product, or a cost model that favors Flex Consumption). If such a reason exists, the
+operator should surface it before L-1 teardown — but it does **not** change this
+plan's low-risk half (freeze + de-dup toward SWA), which is correct either way.
+
+## Goal / Non-goals
+- **Goal:** One canonical backend (SWA); the other frozen and clearly marked, so
+  drift stops.
+- **Goal:** `CLAUDE.md` and a new ADR record the decision.
+- **Non-goal:** Deleting `api/` or its Azure infra (that's L-1, trigger-gated).
+- **Non-goal:** Extracting a shared code package for the two trees. Do **not** build a
+  shared lib — investing in sharing code between a canonical tree and a
+  decommission-bound tree is wasted effort. The right move is to stop touching the
+  dead tree, not to couple them more cleanly.
+
+## Current state
+- `app/api/{waitlist,contact/sales,contact/support,feedback-campaign,health}/route.ts`
+  + `app/feedback/api/submit/route.ts` — live, frontend-called.
+- `api/src/functions/{waitlist,contactSales,contactSupport,feedbackCampaign,feedbackSubmit,health}.ts`
+  — deployed, unused.
+- `api/src/lib/*` — 9 files byte-identical to `lib/*`; `rate-limit.ts` diverged.
+- No CI workflow deploys the Functions app (manual `az`/`func` per `CLAUDE.md`), so
+  "freezing" needs no pipeline change.
+- `infra/main.bicep` provisions the Functions/Storage/App Insights + KV refs.
+
+## Target state
+- A `FROZEN.md` (or header banner) in `api/` states: "This Azure Functions backend is
+  frozen and slated for decommission (see `docs/strategy/ROADMAP.md` L-1). It serves
+  no production traffic. Do not add features here; make backend changes in the SWA
+  `app/api/*` routes." 
+- `CLAUDE.md` updated per `PLAN-004` to name SWA as canonical.
+- An ADR (`PLAN-009`) records the decision and its trigger for teardown.
+- `rate-limit.ts` divergence noted (the SWA copy is canonical; the `api/` copy is
+  frozen as-is — do **not** spend effort reconciling a frozen file).
+
+## Steps
+1. **Confirm the reality once more before acting** (the decision rests on it):
+   - `git grep -nE "func-btai-asp-prod|azurewebsites\.net|NEXT_PUBLIC_API" app/ components/ lib/`
+     → confirm no frontend `fetch` targets the Functions host. (If this surprises and
+     something *does* call Functions, **stop** and re-scope — but recon says it does
+     not.)
+2. **Add `api/FROZEN.md`** with the banner text above and a link to
+   `docs/strategy/ROADMAP.md`.
+3. **Add a top-of-file comment** to each `api/src/functions/*.ts` handler:
+   `// FROZEN — not in production request path. See api/FROZEN.md. Make changes in app/api/*.`
+4. **Update `CLAUDE.md`** (coordinate with `PLAN-004`) so the API-architecture
+   section names SWA canonical and Functions decommission-pending.
+5. **Do not** modify `infra/main.bicep`, delete `api/`, or change Azure resources.
+   Leave the deployed Functions app running until L-1's trigger fires (removing it now
+   risks an unknown dependency; leaving it costs little at Flex Consumption idle).
+6. **Record the L-1 teardown trigger** explicitly in the ADR: "Decommission when SWA
+   routes confirmed serving 100% of prod traffic for 30 days (verify via App Insights
+   request logs on both the SWA and the Functions app) and no other consumer is
+   found."
+
+## Security & compliance notes
+- Freezing reduces the maintained attack surface to one backend. The frozen
+  Functions app remains deployed and anonymous (`authLevel:"anonymous"`) — note in the
+  ADR that its public endpoints (waitlist/contact/feedback) are still reachable
+  directly by URL even though the frontend doesn't use them, so its abuse surface
+  (email-bomb, `feedbackSubmit` IDOR) persists until L-1. If that residual surface is
+  a concern before teardown, the operator can disable the Functions app in Azure
+  (stop, don't delete) as an interim step — flag as an operator option, not required.
+- No secrets touched.
+
+## Validation
+- `api/FROZEN.md` exists and is referenced from `CLAUDE.md` and the ADR.
+- Every `api/src/functions/*.ts` carries the FROZEN header comment.
+- `git grep` confirms (again) no frontend call to the Functions host.
+- No infra or deploy behavior changed: `npm run build` and the SWA deploy are
+  unaffected (this plan touches only `api/` docs/comments + `CLAUDE.md`).
+
+## Rollback
+Documentation/comment-only; `git revert` restores. The decision is reversible on
+paper until L-1 executes the (irreversible) infra teardown — which is deliberately
+out of scope here.

--- a/docs/strategy/plans/PLAN-007-resolve-csrf-and-fix-rate-limiting.md
+++ b/docs/strategy/plans/PLAN-007-resolve-csrf-and-fix-rate-limiting.md
@@ -1,0 +1,107 @@
+# PLAN-007: Resolve CSRF & fix rate-limiting for Azure edge
+**Status**: Ready
+**Effort**: M · **Risk**: Low
+
+## Context
+Two related public-endpoint hardening items, both currently in a false state:
+
+1. **CSRF is decorative.** A full validator exists (`lib/csrf.ts:69-110`) but has
+   **zero importers**; `app/api/csrf/route.ts` just returns a `crypto.randomUUID()`
+   with no cookie set and no server-side storage. No state-changing route validates a
+   CSRF token. This is worse than absent — it reads as "we have CSRF" when we don't.
+
+2. **Rate limiting is coarse and edge-broken.** `lib/rate-limit.ts:50-55`, in
+   production, truncates the client IP to its first two octets
+   (`ip.split(".").slice(0,2).join(".") + ".x.x"`), collapsing every user in the same
+   `/16` into one bucket — so legitimate users behind a shared range get false-blocked,
+   while an attacker rotates to a different `/16` to evade. It also reads the entire
+   `x-forwarded-for` header as the key; behind Azure's edge the header is
+   `client_ip, edge_ip`, so the key is polluted. (It is also in-memory/per-instance —
+   that limitation is real but out of scope here; the durable-store move is
+   `ROADMAP.md` L-4, trigger-gated.)
+
+Fix only the **canonical SWA copy** (`lib/rate-limit.ts`); the `api/` copy is frozen
+(`PLAN-006`).
+
+## The decisions (pre-resolved)
+- **CSRF: remove it, don't half-wire it.** The public forms (waitlist, contact,
+  feedback) are anonymous and session-less — classic CSRF (riding a victim's ambient
+  auth cookie) does not apply, so a token adds friction with no protection. The admin
+  mutations run under a NextAuth session cookie that is `SameSite` by default, which
+  already blocks cross-site form POSTs, and are now authz-gated by `PLAN-001`. So the
+  decorative CSRF protects nothing that isn't already protected. **Delete
+  `lib/csrf.ts` and `app/api/csrf/route.ts`.** If a future feature adds a
+  sensitive, cookie-authenticated cross-origin mutation, add CSRF then — deliberately,
+  wired end-to-end.
+- **Rate limiting: keep in-memory, fix the key.** Parse `x-forwarded-for` correctly
+  (first IP), and replace the `/16` truncation with a salted hash of the full client
+  IP — preserving per-client granularity while not storing raw IPs (the stated
+  privacy goal). Durable cross-instance limiting is L-4, not now.
+
+## Current state
+- `lib/csrf.ts` (126 lines) — `generateCsrfToken`/`validateCsrfToken`, 0 importers.
+- `app/api/csrf/route.ts` — GET returns a UUID; rate-limited; no cookie/storage.
+- `lib/rate-limit.ts:48-55` — IP extraction + `/16` truncation in production.
+- Consumers of `rateLimit(...)`: `app/api/waitlist/route.ts:34`,
+  `app/api/csrf/route.ts` (being deleted), `app/api/contact/*`, and others. The
+  function signature stays the same; only its internal keying changes.
+
+## Target state
+- No `lib/csrf.ts`, no `app/api/csrf` route, no dangling imports.
+- `lib/rate-limit.ts` keys on `sha256(salt + firstXffIp)`; no `/16` collapse; same
+  public `rateLimit(request, config)` signature so callers are unchanged.
+
+## Steps
+1. **Remove CSRF.**
+   - `git grep -nE "csrf|Csrf|CSRF"` across `app/`, `components/`, `lib/`, `e2e/` to
+     confirm the only references are `lib/csrf.ts` and `app/api/csrf/route.ts`
+     themselves (recon says so). Remove any incidental import if one appears.
+   - `git rm lib/csrf.ts && git rm -r app/api/csrf`.
+   - If `staticwebapp.config.json` names `/api/csrf`, remove that rule (none
+     expected).
+2. **Fix IP extraction in `lib/rate-limit.ts`:**
+   - Replace the header read with: take `x-forwarded-for`, split on `,`, use the
+     **first** entry trimmed; fall back to `x-real-ip`, then `"unknown"`.
+   - Replace the production `/16` truncation block (`:50-55`) with a salted hash:
+     ```ts
+     import { createHash } from "crypto";
+     const salt = process.env.RATE_LIMIT_SALT ?? "";
+     const key = createHash("sha256").update(salt + clientIp).digest("hex");
+     ```
+     Use `key` (not the raw IP) as the map key in all environments. This removes the
+     privacy motivation for truncation (raw IP is never stored) while keeping
+     per-client granularity.
+   - Add `RATE_LIMIT_SALT` to `.env.example` and to the SWA app settings (a non-secret
+     random string; if absent the limiter still works, just unsalted).
+   - Keep the in-memory `Map`, the `setInterval` cleanup, and the
+     `DISABLE_RATE_LIMIT` dev escape unchanged.
+   - Fix the stale doc comment (`lib/rate-limit.ts` says `windowMs` is "in seconds"
+     but callers pass milliseconds, e.g. `60*60*1000`) — correct the comment to
+     milliseconds; do **not** change the numeric behavior.
+3. **Do not touch `api/src/lib/rate-limit.ts`** (frozen per `PLAN-006`).
+
+## Security & compliance notes
+- Removing decorative CSRF eliminates false assurance; document the rationale in the
+  ADR (`PLAN-009`) so a future reviewer doesn't "add CSRF back" without cause.
+- Salted-hash keying is a small **privacy improvement** (no raw IPs in memory) and a
+  **correctness improvement** (real per-client limiting) — note both as SOC 2
+  data-minimization + abuse-control evidence.
+- Residual: per-instance in-memory limits still multiply across instances; L-4
+  addresses it when volume warrants. State this honestly in the ADR.
+
+## Validation
+- `git grep -niE "csrf"` → no code references remain.
+- `npm run build && npm run typecheck && npm run lint` clean.
+- Add unit tests (feeds `PLAN-008`) for `lib/rate-limit.ts`:
+  - Same `x-forwarded-for` first-IP → shares a bucket; different first-IP → separate
+    buckets (no `/16` collapse: `1.2.3.4` and `1.2.9.9` must be **different** keys).
+  - Exceeding `limit` within `windowMs` returns a 429 `NextResponse`; under the limit
+    returns `null`.
+- Local: `curl` the waitlist endpoint 6× rapidly from the same simulated
+  `X-Forwarded-For: 1.2.3.4` → the 6th returns 429; a request with `1.2.9.9` is not
+  blocked (proving no `/16` collapse).
+
+## Rollback
+`git revert`. CSRF removal and the rate-limit keying change are independent commits —
+revert either alone. The `rateLimit()` signature is unchanged, so callers need no
+rollback.

--- a/docs/strategy/plans/PLAN-008-kill-test-theater-and-backfill-critical-tests.md
+++ b/docs/strategy/plans/PLAN-008-kill-test-theater-and-backfill-critical-tests.md
@@ -1,0 +1,110 @@
+# PLAN-008: Kill test theater & backfill critical-path tests
+**Status**: Ready (do after `PLAN-005`)
+**Effort**: M · **Risk**: Low
+
+## Context
+The test suite passes (54 tests) but overstates what it protects, and several parts
+are theater:
+- **Coverage gate is cosmetic.** `vitest.config.ts:31-34` sets thresholds to `0`
+  whenever `CI` is set, and `npm test` never runs `--coverage`. The advertised "70%"
+  bites only a developer manually running `test:coverage` with `CI` unset.
+- **A non-failing test.** `__tests__/lib/supabase.test.ts:68-85` ("handle errors
+  gracefully") asserts a shape in the success branch **or** an error **or**
+  `toBeDefined()` in catch — no input can fail it. The whole file runs in mock mode,
+  so it tests the mock, not Supabase.
+- **Self-skipping e2e.** `e2e/landing.spec.ts:63-66` wraps the pricing test in
+  try/catch → `test.skip()` on any error; it cannot fail on a broken pricing toggle.
+  `e2e/visual.spec.ts` self-skips entirely under `CI`/`DOCKER`.
+- **Critical paths untested:** `lib/validation.ts`, `lib/rate-limit.ts`, the
+  `/api/admin/*` authz (the `PLAN-001` fix), and the waitlist route have no tests.
+
+This plan makes the gate honest and adds tests where a regression would actually
+hurt. It runs **after `PLAN-005`** (the CI gate must exist for tests to protect
+anything) and **after `PLAN-001`/`PLAN-007`** (so the new tests assert the fixed
+behavior).
+
+## Goal / Non-goals
+- **Goal:** Coverage thresholds enforced in CI at an honest floor that can only
+  ratchet up.
+- **Goal:** The non-failing test and the always-green landing e2e assert real
+  outcomes.
+- **Goal:** Unit tests exist for validation, rate-limiting, admin authz, and the
+  waitlist route's happy/sad paths.
+- **Non-goal:** Adding Playwright e2e to CI (browsers + time; visual self-skip is a
+  legitimate headless-flakiness guard). Keep e2e local for now; document it.
+- **Non-goal:** Chasing a coverage number for its own sake. Add tests where failure
+  = user harm, not to hit a percentage.
+
+## Current state
+- `vitest.config.ts:12` include = `app/`, `lib/`, `components/`; `api/` is out of
+  scope (frozen — `PLAN-006`).
+- `package.json:18,20` — `test` = `vitest run`; `test:coverage` = `vitest run
+  --coverage`.
+- 8 test files (see `STRATEGIC_REVIEW.md` §5.6 provenance / the test recon).
+
+## Target state
+- `vitest.config.ts` thresholds enforced regardless of `CI`, set to the measured
+  current floor.
+- The CI `validate` job (`PLAN-005`) runs `test:coverage`, not bare `test`.
+- `supabase.test.ts` error case makes a definite assertion.
+- `landing.spec.ts` pricing test fails on a broken toggle.
+- New tests: `__tests__/lib/validation.test.ts`,
+  `__tests__/lib/rate-limit.test.ts`, `__tests__/api/admin-authz.test.ts` (or an e2e
+  equivalent), `__tests__/api/waitlist.test.ts`.
+
+## Steps
+1. **Measure the honest floor.** Run `CI= npm run test:coverage` and record the
+   actual lines/branches/functions/statements percentages.
+2. **Make thresholds real.** In `vitest.config.ts:30-35`, remove the
+   `process.env.CI ? 0 : 70` ternary. Set each threshold to the **measured floor
+   rounded down to the nearest 5%** (e.g. if lines=41%, set 40). This is an honest
+   ratchet: it can't regress and is raised as tests are added. Do **not** set 70 if
+   the code isn't there yet — a threshold that fails every build gets disabled, which
+   is how it became `CI ? 0` in the first place.
+3. **Enforce in CI.** In `.github/workflows/validate.yml` (`PLAN-005`), change the
+   test step from `npm test` to `npm run test:coverage` so the threshold actually
+   gates. Keep the `env` block; add nothing secret.
+4. **Fix the non-failing test** (`__tests__/lib/supabase.test.ts:68-85`): rewrite it
+   to assert a specific outcome. In mock mode, `addToWaitlist` with a valid input
+   returns `{ success: true, user: {...} }`; assert exactly that. If you want an
+   error path, force one (e.g. invalid input the mock rejects) and assert
+   `success === false`. Remove the three-way "or toBeDefined" escape.
+5. **Fix the always-green landing e2e** (`e2e/landing.spec.ts:44-66`): remove the
+   try/catch-that-skips. Assert the pricing toggle is visible and that toggling
+   changes the displayed price. If the toggle legitimately may not render, that's a
+   product bug to surface, not skip.
+6. **Backfill critical unit tests:**
+   - `__tests__/lib/validation.test.ts` — for `waitlistSchema` and each contact
+     schema: valid input passes; over-length name/email/message rejected; malformed
+     email rejected; missing required field rejected.
+   - `__tests__/lib/rate-limit.test.ts` — the assertions listed in `PLAN-007`
+     Validation (first-IP keying, no `/16` collapse, 429 over limit, null under).
+   - `__tests__/api/admin-authz.test.ts` — unauthenticated `POST /api/admin/clear-data`
+     and `GET /api/admin/email-stats` return 401 (the `PLAN-001` regression guard).
+     Mock `auth()` to return no session; assert the route handler 401s.
+   - `__tests__/api/waitlist.test.ts` — happy path (valid body → 200, mocks for
+     `addToWaitlist`/`sendWaitlistConfirmationEmail`); sad paths (invalid JSON → 400,
+     schema failure → 422, missing `RESEND_API_KEY` → 503). Follow the existing mock
+     style (`vi.mock`, `vi.mocked`) from `__tests__/lib/*`.
+7. **Document the e2e stance.** Add a short note in `docs/` (or the ADR) that
+   Playwright e2e runs locally/on-demand, not in CI, and why (browser + dev-server
+   cost); visual snapshots self-skip in headless environments by design.
+
+## Security & compliance notes
+- The admin-authz test is a **security regression guard** — it prevents the
+  `PLAN-001` fix from silently regressing. Note it as SOC 2 change-control evidence.
+- No secrets in tests; all external calls (Supabase, Resend) are mocked.
+
+## Validation
+- `CI=1 npm run test:coverage` — passes and **enforces** the new thresholds (verify
+  by temporarily lowering coverage and seeing it fail).
+- New test files run and pass; total test count increases (>54).
+- The rewritten `supabase.test.ts` error case fails if you deliberately break the
+  mock's return shape (proving it's a real assertion).
+- The `validate` CI job (from `PLAN-005`) now runs coverage and would fail on a
+  coverage drop below the floor.
+
+## Rollback
+`git revert` per commit. Reverting the threshold change restores the prior
+(cosmetic) config; reverting a test file removes only that test. No product behavior
+depends on these changes.

--- a/docs/strategy/plans/PLAN-009-consolidate-docs-and-seed-adrs.md
+++ b/docs/strategy/plans/PLAN-009-consolidate-docs-and-seed-adrs.md
@@ -1,0 +1,105 @@
+# PLAN-009: Consolidate docs & seed an ADR system
+**Status**: Ready (do after `PLAN-003`, `PLAN-004`, `PLAN-006`)
+**Effort**: M · **Risk**: Low
+
+## Context
+`docs/` holds 51 files plus a scatter of root-level notes. Many are point-in-time
+fix logs (`build-error-resolution.md`, `typescript-fixes-summary.md`,
+`static-export-api-fix.md`, `nextauth-static-export.md`), and there are large
+redundant clusters: 9 dependency docs, 5 email docs, 3 typescript-fix docs, 6+
+TODO/status/plan trackers. Crucially, **there is no `docs/adr/` or `docs/decisions/`**
+— the "why" of every architectural choice is either unrecorded or buried in a fix
+log. This review just made several durable decisions (SWA canonical, CSRF removal,
+secret rotation) that must be captured where a future session will find them.
+
+Run this **after** the plans whose decisions it records (`PLAN-003/004/006`, and
+ideally `PLAN-000/007`).
+
+## Goal / Non-goals
+- **Goal:** A lightweight ADR system under `docs/adr/`, seeded with the decisions
+  from this review.
+- **Goal:** The docs graveyard pruned/archived so living reference docs are findable.
+- **Non-goal:** Rewriting the good reference docs (`API.md`, `CODEBASE.md`,
+  `COMPONENTS.md`, `docs/security/*`, `prd.md`). Leave content; only relocate the
+  cruft around them.
+- **Non-goal:** Deleting history. Point-in-time logs move to `docs/archive/`, not the
+  bin, unless clearly worthless.
+
+## Current state
+- No ADR directory.
+- Root transient notes: `ci-cd-fixes.md`, `dependency-report.md`, `email-setup.md`,
+  `fix-supabase-rls.md`, `todo.md`.
+- `docs/` clusters: dependency ×9 (`dependency-*.md`, `zod-installation-checklist.md`),
+  email ×5 (`EMAIL.md`, `EMAIL_RELAY.md`, `email-relay-setup.md`,
+  `email-config-fix.md`, + root `email-setup.md`), typescript-fix ×3, trackers
+  (`MASTER-TODO.md`, `TODO.md`, `typescript-todo.md`, `v2-implementation-plan.md`,
+  `project-status.md`, `production-readiness.md`).
+- Living reference: `API.md`, `API-ARCHITECTURE.md`, `CODEBASE.md`, `COMPONENTS.md`,
+  `NEXT-APP-ROUTER.md`, `docs/security/*` (7), `prd.md`.
+
+## Target state
+- `docs/adr/0000-template.md` + seeded ADRs (see Steps).
+- `docs/archive/` holding the point-in-time fix logs and superseded trackers.
+- One consolidated `docs/DEPENDENCIES.md` and one `docs/EMAIL.md` (or a clear
+  index) replacing the 9+5 sprawl; originals archived.
+- Root transient notes moved into `docs/` or `docs/archive/`; root holds only
+  `README.md`, `CLAUDE.md`, `STANDARDS.md`.
+- `docs/strategy/` (this review) referenced from `CLAUDE.md` and `README.md`.
+
+## Steps
+1. **Create the ADR system.**
+   - `docs/adr/0000-template.md` — a minimal MADR-style template: Title, Status
+     (Proposed/Accepted/Superseded), Context, Decision, Consequences, Date.
+   - Seed these ADRs (each ~1 screen), marked **Accepted**, dated 2026-07-03,
+     cross-linking the plan that implements them:
+     - `0001-swa-api-routes-are-canonical.md` — from `PLAN-006`. Record the decision,
+       the reasons, and the L-1 teardown trigger for the Functions backend.
+     - `0002-remove-decorative-csrf.md` — from `PLAN-007`. Record why anonymous forms
+       don't need CSRF and admin is SameSite+session protected; note "revisit if a
+       cookie-authenticated cross-origin mutation is added."
+     - `0003-ci-validation-gate.md` — from `PLAN-005`. Record that deploy is
+       gated by a PR validation workflow; deploy stays deploy-only.
+     - `0004-in-repo-secret-rotation-2026-07.md` — from `PLAN-000`. An
+       incident/decision record: what was exposed, that it was rotated, and the
+       history-scrub decision the operator made. (Do **not** include secret values.)
+2. **Create `docs/archive/`** and `git mv` the point-in-time logs into it:
+   `build-error-resolution.md`, `typescript-fixes-summary.md`,
+   `typescript-fix-progress.md`, `typescript-todo.md`, `static-export-api-fix.md`,
+   `nextauth-static-export.md`, `email-config-fix.md`, `ci-cd-implementation-report.md`,
+   and the superseded dependency-*.md once consolidated (Step 3). Keep them in git
+   history; archiving just declutters the active dir.
+3. **Consolidate clusters.**
+   - Dependency docs: create `docs/DEPENDENCIES.md` that states the current policy
+     (exact pins, shrinkwrap, Dependabot, the L-2 upgrade campaign) and links to the
+     archived detail. `git mv` the 9 source docs to `docs/archive/`.
+   - Email docs: create/keep a single `docs/EMAIL.md` as the canonical email setup +
+     relay reference; archive the other 4.
+4. **Relocate root transient notes:** `git mv ci-cd-fixes.md dependency-report.md
+   email-setup.md fix-supabase-rls.md todo.md docs/archive/` (fold anything still
+   true into the consolidated docs first — e.g. `fix-supabase-rls.md`'s RLS guidance
+   into `docs/security/` since `PLAN-000` Step 2 depends on RLS being correct).
+5. **Wire discoverability:** add a "Strategy & decisions" line to `README.md` and
+   `CLAUDE.md` pointing at `docs/strategy/` and `docs/adr/`.
+6. **Prune the trackers:** `MASTER-TODO.md`/`TODO.md`/`project-status.md` are stale
+   snapshots — archive them; the live roadmap is now `docs/strategy/ROADMAP.md`. Note
+   in the archive that `docs/strategy/` supersedes them.
+
+## Security & compliance notes
+- ADRs are **SOC 2 evidence** (documented decision-making). `0004` is
+  incident-response evidence for the secret rotation — keep it factual and
+  value-free.
+- No code or secret change. When folding `fix-supabase-rls.md` into
+  `docs/security/`, do not paste any connection string or key — reference by name.
+
+## Validation
+- `docs/adr/` contains the template + 4 seeded ADRs; each links its implementing
+  plan.
+- `ls docs/*.md | wc -l` is materially smaller; the active `docs/` root holds
+  reference docs + `DEPENDENCIES.md` + `EMAIL.md`, not the fix-log sprawl.
+- Root dir holds only `README.md`, `CLAUDE.md`, `STANDARDS.md` (plus non-doc files).
+- `README.md` and `CLAUDE.md` link to `docs/strategy/` and `docs/adr/`.
+- No broken relative links: `git grep -oE '\]\(\.?\.?/?docs/[^)]+\)'` — spot-check
+  moved targets resolve.
+
+## Rollback
+All `git mv`/additions; `git revert` restores prior layout. Pure documentation.


### PR DESCRIPTION
Adds `docs/strategy/` from the 2026-07 portfolio strategy review sweep (strategic review, roadmap, execution plans). Docs-only; no code or CI surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)