### PR TITLE
chore(dependabot): move the weekly slot to tuesday 10:00 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/New_York"
+      day: "tuesday"
+      time: "10:00"
+      timezone: "Etc/UTC"
     # Apply our exact versioning strategy
     versioning-strategy: "lockfile-only"
     # Limit the number of open PRs to avoid overwhelming
@@ -61,7 +61,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      time: "10:00"
+      timezone: "Etc/UTC"
+      day: "tuesday"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
## What

Moves this repo's weekly Dependabot slot to **tuesday 10:00 UTC**.

STANDARDS § 8 and § 15 require the weekly slot to be staggered across **Tue–Sat**, never the retired **Monday 14:00 UTC** slot — the simultaneous Monday burst exhausted the GitHub Actions allowance on **2026-06-21**. This repo was on `monday 09:00`.

Only `schedule:` blocks with `interval: weekly` are touched. `open-pull-requests-limit`, `groups` and `labels` are unchanged.

## Slot assignment

Originally assigned by the Olympus survey in `docs/DEPENDABOT-STAGGER-REMEDIATION.md`. That survey only globbed `~/dev/Herculean*` and `~/dev/engram` — **18 repos** — but **31 repos** carry a Dependabot config, so 4 of its 8 assignments collided with repos it never looked at.

This slot was re-verified unoccupied against **all 31** on 2026-07-28.

⚠️ This repo declared `timezone: America/New_York`; it is now `Etc/UTC` to match the fleet. That is a **real shift in fire time**, not just a relabel. Its second weekly block declared no `time`/`timezone` at all and now does. Its third block is `monthly` and is left untouched.

## Verification

- no `day:` value resolves to monday or sunday
- every weekly block carries an explicit `day`, `time` and `timezone`
- pre-commit run on the changed file
- header comments naming the old slot updated so they cannot contradict the config

Part of the fleet-wide stagger remediation; the Olympus doc is being corrected in the same pass, along with a new **S31** rule so this is held mechanically instead of by convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HDXTwVi2fbm3kfAR1xMwT
